### PR TITLE
   Feat : Logging Slf4j, messages d'erreur explicites et trajets publics

### DIFF
--- a/docker/mysql/initdb/02_data.sql
+++ b/docker/mysql/initdb/02_data.sql
@@ -1,32 +1,101 @@
 -- =============================================================
--- PapoteCar - Script de données initiales (jeu de test)
--- Mots de passe encodés BCrypt (valeur : "Test123")
+-- PapoteCar — Jeu de données de test
+-- Mot de passe BCrypt : "Test123"
+-- =============================================================
+--
+-- STRUCTURE DU JEU DE DONNÉES
+-- ─────────────────────────────────────────────────────────────
+-- user1 (id=1) : conducteur principal — permis=1, solde=200.00
+-- user2 (id=2) : passager riche       — permis=0, solde=50.00
+-- user3 (id=3) : passager pauvre      — permis=0, solde=5.00
+--
+-- voiture1 (id=1) : user1 — 3 places — UTILISÉE dans trajet actif → 409 PATCH/DELETE
+-- voiture2 (id=2) : user1 — 2 places — libre                      → OK  PATCH/DELETE
+--
+-- TRAJETS (tous conducteur=user1)
+-- trajet1 (id=1) : actif   voiture1 Paris→Lyon        prix=15 places=2  → tests réservations
+-- trajet2 (id=2) : terminé voiture2 Paris→Marseille   prix=10 places=0  → 409 PATCH/DELETE/terminer
+-- trajet3 (id=3) : annulé  voiture2 Paris→Bordeaux    prix=12 places=2  → 409 DELETE/terminer/réserver
+-- trajet4 (id=4) : actif   voiture1 Paris→Nantes      prix=20 places=0  → 409 réserver complet / 409 valider complet
+-- trajet5 (id=5) : actif   voiture2 Paris→Strasbourg  prix=8  places=3  → trajet vierge POST réservation 201
+--
+-- RÉSERVATIONS
+-- resa1 (id=1) : user2 / trajet1 / en_attente → PUT valider 200 (50≥15) · PUT refuser 200 · GET · DELETE annuler
+-- resa2 (id=2) : user3 / trajet1 / en_attente → PUT valider 409 solde insuff (5<15)
+-- resa3 (id=3) : user2 / trajet2 / valide     → DELETE réservation valide (remboursement +10 au solde)
+-- resa4 (id=4) : user2 / trajet3 / annule     → DELETE 409 déjà annulée
+-- resa5 (id=5) : user3 / trajet4 / en_attente → PUT valider 409 trajet complet (0 places)
+--
+-- CAS DE TEST COUVERTS PAR ROUTE
+-- ─────────────────────────────────────────────────────────────
+-- GET  /user/me                      200 (user1)
+-- GET  /user/{id}                    200 propre profil (email+tel+solde visibles)
+--                                    200 profil autre  (email+tel+solde masqués)
+--                                    404 id inexistant
+-- PATCH /user/{id}                   200 user1 → user1
+--                                    403 user1 → user2
+-- GET  /user/{id}/trajets            200 avec trajets (user1) · 200 vide (user2/user3)
+-- DELETE /user/{id}                  409 user1 a trajet actif (trajet1, trajet4)
+--                                    403 user1 supprime user2
+--                                    204 user2 ou user3 supprime son propre compte (pas de trajet actif)
+--
+-- GET  /voitures                     200 liste (user1 : 2 voitures)
+-- GET  /voiture/{id}                 200 · 403 non-propriétaire · 404
+-- POST /voitures                     201
+-- PATCH /voiture/{id}                409 voiture1 (trajet actif) · 200 voiture2 (libre) · 403
+-- DELETE /voiture/{id}               409 voiture1 (trajet actif) · 200 voiture2 (libre) · 403
+--
+-- GET  /trajets                      200 sans filtres · 200 avec filtres ville · 200 avec GPS
+-- GET  /trajets/mes-trajets          200 (user1 : 5 trajets)
+-- GET  /trajets/{id}                 200 · 404
+-- POST /trajets                      201 · 403 sans permis (user2/user3)
+-- PATCH /trajets/{id}                200 actif · 409 terminé · 409 annulé · 403
+-- DELETE /trajets/{id}               204 actif · 409 terminé · 409 annulé · 403
+-- PUT  /trajets/{id}/terminer        200 actif · 409 terminé · 409 annulé · 403
+--
+-- POST /trajets/{id}/reservations    201 vierge (trajet5)
+--                                    400 réserver son propre trajet (user1 sur trajet5)
+--                                    409 trajet inactif (trajet2 terminé, trajet3 annulé)
+--                                    409 déjà réservé (user2 tente resa sur trajet1 à nouveau)
+--                                    409 complet (trajet4 places=0)
+-- GET  /trajets/{id}/reservations    200 conducteur (user1 sur trajet1) · 403 non-conducteur
+-- GET  /reservations/{id}            200 passager (user2 → resa1) · 200 conducteur (user1 → resa1) · 403 tiers
+-- DELETE /reservations/{id}          204 en_attente sans remboursement (resa1)
+--                                    204 valide avec remboursement    (resa3 user2+10)
+--                                    409 déjà annulée                  (resa4)
+--                                    403 non-passager
+-- PUT  /reservations/{id}/valider    200 en_attente OK (resa1 : user2 solde 50≥15)
+--                                    409 solde insuff  (resa2 : user3 solde 5<15)
+--                                    409 trajet complet (resa5 : trajet4 places=0)
+--                                    409 déjà validée/refusée
+--                                    403 non-conducteur
+-- PUT  /reservations/{id}/refuser    200 en_attente (resa2) · 409 déjà refusée · 403
 -- =============================================================
 
 USE papotecar;
 
 -- -------------------------------------------------------------
--- Utilisateurs (5 conducteurs / passagers)
+-- Utilisateurs
 -- -------------------------------------------------------------
 INSERT INTO utilisateurs (nom, prenom, username, email, mot_de_passe, tel, permis_de_conduire, solde) VALUES
-('Dupont',   'Alice',   'alice.d',   'alice.dupont@email.com',   '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0601020304', 1, 100.00),
-('Martin',   'Bob',     'bob.m',     'bob.martin@email.com',     '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0611223344', 1,  75.00),
-('Bernard',  'Camille', 'camille.b', 'camille.bernard@email.com','$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0622334455', 0,  50.00),
-('Leroy',    'David',   'david.l',   'david.leroy@email.com',    '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0633445566', 0,  40.00),
-('Moreau',   'Emma',    'emma.m',    'emma.moreau@email.com',    '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0644556677', 0,  60.00);
+-- user1 : conducteur principal (permis + solde élevé)
+('Martin',  'Alice',  'alice',  'alice@papotecar.fr',  '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0601020304', 1, 200.00),
+-- user2 : passager riche (solde 50 > prix trajet1=15 → validation OK)
+('Dupont',  'Bob',    'bob',    'bob@papotecar.fr',    '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0611223344', 0,  50.00),
+-- user3 : passager pauvre (solde 5 < prix trajet1=15 → validation 409)
+('Leroy',   'Claire', 'claire', 'claire@papotecar.fr', '$2a$10$Lj2TvhV3ne5.CWpNXSaxzOEPGSww54osDrL.DHitrW8k9smZkSk/i', '0622334455', 0,   5.00);
 
 -- -------------------------------------------------------------
--- Voitures
+-- Voitures (propriétaire : user1)
 -- -------------------------------------------------------------
-INSERT INTO voitures (utilisateur_id, modele, nb_passagers, taille_coffre) VALUES
-(1, 'Renault Zoé',         3, 'Moyen'),
-(2, 'Peugeot e-208',       3, 'Petit'),
-(3, 'Tesla Model 3',       4, 'Grand'),
-(4, 'Volkswagen ID.4',     4, 'Grand'),
-(5, 'Toyota Yaris Cross',  3, 'Moyen');
+INSERT INTO voitures (utilisateur_id, modele, nb_passagers, couleur, taille_coffre) VALUES
+-- voiture1 : utilisée dans trajet1 (actif) et trajet4 (actif) → PATCH/DELETE → 409
+(1, 'Renault Zoé',  3, 'Blanche', 'Moyen'),
+-- voiture2 : utilisée dans trajet2 (terminé) et trajet3 (annulé) → PATCH/DELETE → 200
+(1, 'Peugeot 208',  2, 'Grise',   'Petit');
 
 -- -------------------------------------------------------------
--- Trajets (DATE_ADD imbriqués — syntaxe MySQL valide)
+-- Trajets (conducteur + voiture : user1)
 -- -------------------------------------------------------------
 INSERT INTO trajets (
     conducteur_id, voiture_id,
@@ -35,64 +104,87 @@ INSERT INTO trajets (
     horaire_depart, horaire_arrivee, temps_trajet_min, places_disponibles, prix, statut
 ) VALUES
 
--- Trajet 1 : Alice  Paris -> Lyon (actif, demain)
+-- ── trajet1 : ACTIF — voiture1 — Paris→Lyon — prix=15 — places=2
+-- Cas couverts : socle de tous les tests réservation, PATCH trajet 200,
+--               409 DELETE user1 (trajet actif), 409 PATCH/DELETE voiture1
 (1, 1,
- '10 Rue de Rivoli', 'Paris', '75001', 48.857000, 2.351000,
- '1 Place Bellecour', 'Lyon', '69002', 45.757800, 4.832000,
- DATE_ADD(NOW(), INTERVAL 1 DAY),
- DATE_ADD(DATE_ADD(NOW(), INTERVAL 1 DAY), INTERVAL 120 MINUTE),
+ '10 Rue de Rivoli',    'Paris', '75001', 48.857000,  2.351000,
+ '1 Place Bellecour',   'Lyon',  '69002', 45.757800,  4.832000,
+ DATE_ADD(NOW(), INTERVAL  2 DAY),
+ DATE_ADD(NOW(), INTERVAL  2 DAY  + INTERVAL 120 MINUTE),
  120, 2, 15.00, 'actif'),
 
--- Trajet 2 : Bob  Lyon -> Marseille (actif, dans 3 jours)
-(2, 2,
- '5 Rue de la Republique', 'Lyon', '69001', 45.763600, 4.835700,
- '20 La Canebiere', 'Marseille', '13001', 43.296400, 5.381000,
- DATE_ADD(NOW(), INTERVAL 3 DAY),
- DATE_ADD(DATE_ADD(NOW(), INTERVAL 3 DAY), INTERVAL 115 MINUTE),
- 115, 3, 12.00, 'actif'),
+-- ── trajet2 : TERMINÉ — voiture2 — Paris→Marseille — prix=10 — places=0
+-- Cas couverts : 409 PATCH trajet, 409 DELETE trajet, 409 PUT/terminer,
+--               409 POST réservation sur trajet inactif,
+--               voiture2 libre pour PATCH/DELETE voiture
+(1, 2,
+ '15 Av. des Champs-Elysées', 'Paris',     '75008', 48.869600,  2.307700,
+ '20 La Canebière',           'Marseille', '13001', 43.296400,  5.381000,
+ DATE_SUB(NOW(), INTERVAL  5 DAY),
+ DATE_SUB(NOW(), INTERVAL  5 DAY  - INTERVAL 115 MINUTE),
+ 115, 0, 10.00, 'termine'),
 
--- Trajet 3 : Camille  Bordeaux -> Toulouse (actif, dans 2 jours)
-(3, 3,
- '3 Allees de Tourny', 'Bordeaux', '33000', 44.841200, -0.580900,
- '8 Place du Capitole', 'Toulouse', '31000', 43.604500, 1.444100,
- DATE_ADD(NOW(), INTERVAL 2 DAY),
- DATE_ADD(DATE_ADD(NOW(), INTERVAL 2 DAY), INTERVAL 130 MINUTE),
- 130, 2, 10.00, 'actif'),
+-- ── trajet3 : ANNULÉ — voiture2 — Paris→Bordeaux — prix=12 — places=2
+-- Cas couverts : 409 DELETE trajet annulé, 409 PUT/terminer trajet annulé,
+--               409 POST réservation sur trajet inactif
+(1, 2,
+ '10 Rue de Rivoli',       'Paris',    '75001', 48.857000,  2.351000,
+ '1 Cours du Chapeau Rouge','Bordeaux', '33000', 44.836100, -0.570600,
+ DATE_ADD(NOW(), INTERVAL  3 DAY),
+ DATE_ADD(NOW(), INTERVAL  3 DAY  + INTERVAL 200 MINUTE),
+ 200, 2, 12.00, 'annule'),
 
--- Trajet 4 : David  Paris -> Bordeaux (termine, passe)
-(4, 4,
- '15 Avenue des Champs-Elysees', 'Paris', '75008', 48.869600, 2.307700,
- '1 Cours du Chapeau Rouge', 'Bordeaux', '33000', 44.836100, -0.570600,
- DATE_SUB(NOW(), INTERVAL 5 DAY),
- DATE_ADD(DATE_SUB(NOW(), INTERVAL 5 DAY), INTERVAL 220 MINUTE),
- 220, 0, 20.00, 'termine'),
-
--- Trajet 5 : Emma  Nice -> Lyon (annule)
-(5, 5,
- '7 Avenue Jean Medecin', 'Nice', '06000', 43.707300, 7.261700,
- '2 Place des Terreaux', 'Lyon', '69001', 45.767900, 4.833600,
- DATE_ADD(NOW(), INTERVAL 4 DAY),
- DATE_ADD(DATE_ADD(NOW(), INTERVAL 4 DAY), INTERVAL 210 MINUTE),
- 210, 3, 18.00, 'annule'),
-
--- Trajet 6 : Alice  Paris -> Nantes (actif, dans 7 jours)
+-- ── trajet4 : ACTIF — voiture1 — Paris→Nantes — prix=20 — places=0 (COMPLET)
+-- Cas couverts : 409 POST réservation (complet), 409 PUT/valider (places=0),
+--               renforce 409 PATCH/DELETE voiture1 (2ème trajet actif)
 (1, 1,
- '10 Rue de Rivoli', 'Paris', '75001', 48.857000, 2.351000,
- '1 Place du Commerce', 'Nantes', '44000', 47.213200, -1.553600,
- DATE_ADD(NOW(), INTERVAL 7 DAY),
- DATE_ADD(DATE_ADD(NOW(), INTERVAL 7 DAY), INTERVAL 140 MINUTE),
- 140, 2, 14.00, 'actif');
+ '10 Rue de Rivoli',   'Paris',  '75001', 48.857000,  2.351000,
+ '1 Place du Commerce','Nantes', '44000', 47.213200, -1.553600,
+ DATE_ADD(NOW(), INTERVAL  4 DAY),
+ DATE_ADD(NOW(), INTERVAL  4 DAY  + INTERVAL 140 MINUTE),
+ 140, 0, 20.00, 'actif'),
+
+-- ── trajet5 : ACTIF — voiture2 — Paris→Strasbourg — prix=8 — places=3 (VIERGE)
+-- Cas couverts : POST réservation 201 (aucune resa pré-existante),
+--               PUT /terminer 200 (en fin de session test)
+(1, 2,
+ '10 Rue de Rivoli',  'Paris',      '75001', 48.857000,  2.351000,
+ '1 Place Kléber',    'Strasbourg', '67000', 48.583800,  7.747900,
+ DATE_ADD(NOW(), INTERVAL  6 DAY),
+ DATE_ADD(NOW(), INTERVAL  6 DAY  + INTERVAL 130 MINUTE),
+ 130, 3,  8.00, 'actif');
 
 -- -------------------------------------------------------------
--- Reservations (tous les statuts representes)
+-- Réservations
 -- -------------------------------------------------------------
 INSERT INTO reservations (trajet_id, passager_id, statut) VALUES
-(1, 2, 'valide'),
+
+-- resa1 : user2 / trajet1 / en_attente
+-- → GET 200 (passager user2 ou conducteur user1)
+-- → PUT /valider 200  (user2 solde=50 ≥ prix=15 ✅)
+-- → PUT /refuser 200
+-- → DELETE 204 annulation sans remboursement (statut=en_attente)
+-- → PUT /valider 409 après refus/validation (statut ≠ en_attente)
+(1, 2, 'en_attente'),
+
+-- resa2 : user3 / trajet1 / en_attente
+-- → PUT /valider 409 solde insuffisant (user3 solde=5 < prix=15)
+-- → PUT /refuser 200 (conducteur user1)
+-- → GET 403 si tiers (ni user3 ni user1)
 (1, 3, 'en_attente'),
-(2, 1, 'en_attente'),
-(2, 5, 'refuse'),
-(3, 4, 'valide'),
-(4, 2, 'valide'),
-(4, 5, 'valide'),
-(6, 4, 'annule'),
-(6, 3, 'en_attente');
+
+-- resa3 : user2 / trajet2 / valide
+-- → DELETE 204 annulation d'une réservation VALIDE → remboursement +10 au solde user2
+-- → GET 200 (user2 ou user1)
+(2, 2, 'valide'),
+
+-- resa4 : user2 / trajet3 / annule
+-- → DELETE 409 "déjà annulée"
+-- → GET 200 (user2 ou user1)
+(3, 2, 'annule'),
+
+-- resa5 : user3 / trajet4 / en_attente (trajet4 a places=0)
+-- → PUT /valider 409 "trajet complet" (places_disponibles=0)
+-- → PUT /refuser 200 (conducteur user1)
+(4, 3, 'en_attente');

--- a/src/main/java/com/PapoteCar/PapoteCar/config/SecurityConfig.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/register", "/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/trajets", "/trajets/{id}").permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**", "/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/PapoteCar/PapoteCar/controller/ReservationController.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/controller/ReservationController.java
@@ -10,6 +10,7 @@ import com.PapoteCar.PapoteCar.repository.ReservationRepository;
 import com.PapoteCar.PapoteCar.repository.TrajetRepository;
 import com.PapoteCar.PapoteCar.repository.UtilisateurRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ReservationController {
@@ -35,26 +37,30 @@ public class ReservationController {
 
     // POST /trajets/{id}/reservations — S'inscrire sur un trajet
     @PostMapping("/trajets/{id}/reservations")
-    public ResponseEntity<ReservationResponse> creerReservation(@PathVariable Integer id) {
+    public ResponseEntity<?> creerReservation(@PathVariable Integer id) {
         Trajet trajet = trajetRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new IllegalArgumentException("Trajet introuvable"));
 
         if (trajet.getStatut() != Trajet.Statut.actif) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit réservation trajet id={} : trajet inactif (statut={})", id, trajet.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de réserver ce trajet : il n'est plus actif");
         }
 
         Utilisateur connecte = utilisateurConnecte();
 
         if (trajet.getConducteur().getId().equals(connecte.getId())) {
-            return ResponseEntity.badRequest().build();
+            log.warn("Réservation refusée : utilisateur id={} tente de réserver son propre trajet id={}", connecte.getId(), id);
+            return ResponseEntity.badRequest().body("Vous ne pouvez pas réserver votre propre trajet");
         }
 
         if (reservationRepository.findByTrajetIdAndPassagerId(id, connecte.getId()).isPresent()) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit réservation trajet id={} : passager id={} a déjà une réservation", id, connecte.getId());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Vous avez déjà une réservation sur ce trajet");
         }
 
         if (trajet.getPlacesDisponibles() <= 0) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit réservation trajet id={} : plus de places disponibles", id);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Ce trajet est complet, il ne reste plus de places disponibles");
         }
 
         Reservation reservation = new Reservation();
@@ -64,6 +70,7 @@ public class ReservationController {
         reservation.setCreatedAt(LocalDateTime.now());
 
         Reservation sauvegardee = reservationRepository.save(reservation);
+        log.info("Réservation créée id={} par passager id={} sur trajet id={}", sauvegardee.getId(), connecte.getId(), id);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new ReservationResponse(
                 sauvegardee.getId(),
@@ -84,6 +91,7 @@ public class ReservationController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!trajet.getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente de lister les réservations du trajet id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -114,6 +122,7 @@ public class ReservationController {
         boolean estConducteur = reservation.getTrajet().getConducteur().getId().equals(connecte.getId());
 
         if (!estPassager && !estConducteur) {
+            log.warn("Accès interdit : utilisateur id={} tente d'accéder à la réservation id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -134,17 +143,19 @@ public class ReservationController {
     // DELETE /reservations/{id} — Se désinscrire (passager)
     @Transactional
     @DeleteMapping("/reservations/{id}")
-    public ResponseEntity<Void> annulerReservation(@PathVariable Integer id) {
+    public ResponseEntity<?> annulerReservation(@PathVariable Integer id) {
         Reservation reservation = reservationRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new IllegalArgumentException("Réservation introuvable"));
 
         Utilisateur connecte = utilisateurConnecte();
         if (!reservation.getPassager().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente d'annuler la réservation id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (reservation.getStatut() == Reservation.Statut.annule) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit annulation réservation id={} : déjà annulée", id);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Cette réservation est déjà annulée");
         }
 
         if (reservation.getStatut() == Reservation.Statut.valide) {
@@ -153,12 +164,15 @@ public class ReservationController {
             trajetRepository.save(trajet);
 
             Utilisateur passager = reservation.getPassager();
-            passager.setSolde(passager.getSolde().add(trajet.getPrix()));
-            utilisateurRepository.save(passager);
+            if (trajet.getPrix() != null) {
+                passager.setSolde(passager.getSolde().add(trajet.getPrix()));
+                utilisateurRepository.save(passager);
+            }
         }
 
         reservation.setStatut(Reservation.Statut.annule);
         reservationRepository.save(reservation);
+        log.info("Réservation annulée id={} par passager id={}", id, connecte.getId());
 
         return ResponseEntity.noContent().build();
     }
@@ -166,27 +180,31 @@ public class ReservationController {
     // PUT /reservations/{id}/valider — Valider un passager (conducteur)
     @Transactional
     @PutMapping("/reservations/{id}/valider")
-    public ResponseEntity<ReservationResponse> validerReservation(@PathVariable Integer id) {
+    public ResponseEntity<?> validerReservation(@PathVariable Integer id) {
         Reservation reservation = reservationRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new IllegalArgumentException("Réservation introuvable"));
 
         Utilisateur connecte = utilisateurConnecte();
         if (!reservation.getTrajet().getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente de valider la réservation id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (reservation.getStatut() != Reservation.Statut.en_attente) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit validation réservation id={} : statut={}", id, reservation.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de valider cette réservation : elle est en statut " + reservation.getStatut());
         }
 
         Trajet trajet = reservation.getTrajet();
         if (trajet.getPlacesDisponibles() <= 0) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit validation réservation id={} : trajet id={} complet", id, trajet.getId());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de valider : le trajet est complet");
         }
 
         Utilisateur passager = reservation.getPassager();
         if (passager.getSolde().compareTo(trajet.getPrix()) < 0) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit validation réservation id={} : solde insuffisant pour passager id={}", id, passager.getId());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de valider : le passager ne dispose pas d'un solde suffisant");
         }
 
         reservation.setStatut(Reservation.Statut.valide);
@@ -198,6 +216,7 @@ public class ReservationController {
         passager.setSolde(passager.getSolde().subtract(trajet.getPrix()));
         utilisateurRepository.save(passager);
 
+        log.info("Réservation validée id={} par conducteur id={}, passager id={}", id, connecte.getId(), passager.getId());
         return ResponseEntity.ok(new ReservationResponse(
                 reservation.getId(),
                 trajet.getId(),
@@ -211,21 +230,24 @@ public class ReservationController {
 
     // PUT /reservations/{id}/refuser — Refuser un passager (conducteur)
     @PutMapping("/reservations/{id}/refuser")
-    public ResponseEntity<ReservationResponse> refuserReservation(@PathVariable Integer id) {
+    public ResponseEntity<?> refuserReservation(@PathVariable Integer id) {
         Reservation reservation = reservationRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new IllegalArgumentException("Réservation introuvable"));
 
         Utilisateur connecte = utilisateurConnecte();
         if (!reservation.getTrajet().getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente de refuser la réservation id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (reservation.getStatut() != Reservation.Statut.en_attente) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit refus réservation id={} : statut={}", id, reservation.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de refuser cette réservation : elle est en statut " + reservation.getStatut());
         }
 
         reservation.setStatut(Reservation.Statut.refuse);
         reservationRepository.save(reservation);
+        log.info("Réservation refusée id={} par conducteur id={}", id, connecte.getId());
 
         Trajet trajet = reservation.getTrajet();
         return ResponseEntity.ok(new ReservationResponse(
@@ -246,6 +268,7 @@ public class ReservationController {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<String> handleIllegalState(IllegalStateException ex) {
+        log.error("Erreur inattendue dans ReservationController : {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/PapoteCar/PapoteCar/controller/TrajetController.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/controller/TrajetController.java
@@ -13,6 +13,7 @@ import com.PapoteCar.PapoteCar.repository.TrajetRepository;
 import com.PapoteCar.PapoteCar.repository.UtilisateurRepository;
 import com.PapoteCar.PapoteCar.repository.VoitureRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class TrajetController {
@@ -183,13 +185,14 @@ public class TrajetController {
         Utilisateur connecte = utilisateurConnecte();
 
         if (!connecte.isPermisDeConduire()) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Permis de conduire requis pour créer un trajet");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         Voiture voiture = voitureRepository.findById(request.getVoitureId())
                 .orElseThrow(() -> new IllegalArgumentException("Voiture introuvable"));
 
         if (!voiture.getUtilisateur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} ne possède pas la voiture id={}", connecte.getId(), request.getVoitureId());
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -237,6 +240,7 @@ public class TrajetController {
         trajet.setCreatedAt(LocalDateTime.now());
 
         Trajet sauvegarde = trajetRepository.save(trajet);
+        log.info("Trajet créé id={} par conducteur id={}", sauvegarde.getId(), connecte.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new TrajetDetailResponse(
                 sauvegarde.getId(),
@@ -274,11 +278,13 @@ public class TrajetController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!trajet.getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente de modifier le trajet id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajet.getStatut() != Trajet.Statut.actif) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit modification trajet id={} : statut={}", id, trajet.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de modifier ce trajet : il est " + trajet.getStatut());
         }
 
         if (request.getDepartRue() != null) trajet.setDepartRue(request.getDepartRue());
@@ -301,6 +307,7 @@ public class TrajetController {
             Voiture voiture = voitureRepository.findById(request.getVoitureId())
                     .orElseThrow(() -> new IllegalArgumentException("Voiture introuvable"));
             if (!voiture.getUtilisateur().getId().equals(connecte.getId())) {
+                log.warn("Accès interdit : utilisateur id={} ne possède pas la voiture id={}", connecte.getId(), request.getVoitureId());
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
             trajet.setVoiture(voiture);
@@ -318,6 +325,7 @@ public class TrajetController {
         }
 
         Trajet sauvegarde = trajetRepository.save(trajet);
+        log.info("Trajet mis à jour id={} par conducteur id={}", id, connecte.getId());
 
         return ResponseEntity.ok(new TrajetDetailResponse(
                 sauvegarde.getId(),
@@ -347,17 +355,19 @@ public class TrajetController {
     // DELETE /trajets/{id} — annuler un trajet (soft delete + cascade reservations)
     @Transactional
     @DeleteMapping("/trajets/{id}")
-    public ResponseEntity<Void> deleteTrajet(@PathVariable Integer id) {
+    public ResponseEntity<?> deleteTrajet(@PathVariable Integer id) {
         Trajet trajet = trajetRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new IllegalArgumentException("Trajet introuvable"));
 
         Utilisateur connecte = utilisateurConnecte();
         if (!trajet.getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente d'annuler le trajet id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajet.getStatut() == Trajet.Statut.annule || trajet.getStatut() == Trajet.Statut.termine) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit annulation trajet id={} : statut={}", id, trajet.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Ce trajet est déjà " + trajet.getStatut() + " et ne peut pas être annulé");
         }
 
         trajet.setStatut(Trajet.Statut.annule);
@@ -369,6 +379,7 @@ public class TrajetController {
         }
         reservationRepository.saveAll(reservations);
 
+        log.info("Trajet annulé id={} par conducteur id={}, {} réservation(s) annulée(s)", id, connecte.getId(), reservations.size());
         return ResponseEntity.noContent().build();
     }
 
@@ -380,15 +391,18 @@ public class TrajetController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!trajet.getConducteur().getId().equals(connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente de terminer le trajet id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajet.getStatut() != Trajet.Statut.actif) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit terminer trajet id={} : statut={}", id, trajet.getStatut());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de terminer ce trajet : il est " + trajet.getStatut());
         }
 
         trajet.setStatut(Trajet.Statut.termine);
         trajetRepository.save(trajet);
+        log.info("Trajet terminé id={} par conducteur id={}", id, connecte.getId());
 
         return ResponseEntity.ok(new TrajetDetailResponse(
                 trajet.getId(),
@@ -422,6 +436,7 @@ public class TrajetController {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<String> handleIllegalState(IllegalStateException ex) {
+        log.error("Erreur inattendue dans TrajetController : {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/PapoteCar/PapoteCar/controller/UtilisateurController.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/controller/UtilisateurController.java
@@ -8,6 +8,7 @@ import com.PapoteCar.PapoteCar.model.Utilisateur;
 import com.PapoteCar.PapoteCar.repository.TrajetRepository;
 import com.PapoteCar.PapoteCar.repository.UtilisateurRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.math.BigDecimal;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
@@ -51,6 +53,7 @@ public class UtilisateurController {
         Utilisateur connecte = utilisateurConnecte();
         connecte.setPermisDeConduire(true);
         utilisateurRepository.save(connecte);
+        log.info("Permis de conduire validé pour utilisateur id={}", connecte.getId());
         return ResponseEntity.ok(new UtilisateurResponse(
                 connecte.getId(),
                 connecte.getNom(),
@@ -93,6 +96,7 @@ public class UtilisateurController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!connecte.getId().equals(id)) {
+            log.warn("Accès interdit : utilisateur id={} tente de modifier le profil id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -101,6 +105,7 @@ public class UtilisateurController {
         if (request.getTel() != null) connecte.setTel(request.getTel());
 
         utilisateurRepository.save(connecte);
+        log.info("Profil mis à jour pour utilisateur id={}", connecte.getId());
 
         return ResponseEntity.ok(new UtilisateurResponse(
                 connecte.getId(),
@@ -137,17 +142,20 @@ public class UtilisateurController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUtilisateur(@PathVariable Integer id) {
+    public ResponseEntity<?> deleteUtilisateur(@PathVariable Integer id) {
         Utilisateur connecte = utilisateurConnecte();
         if (!connecte.getId().equals(id)) {
+            log.warn("Accès interdit : utilisateur id={} tente de supprimer le compte id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajetRepository.existsByConducteurIdAndStatut(id, Trajet.Statut.actif)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit suppression compte id={} : trajet actif en cours", id);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de supprimer votre compte : vous avez un trajet actif en cours");
         }
 
         utilisateurRepository.deleteById(id);
+        log.info("Compte supprimé id={}", id);
         return ResponseEntity.noContent().build();
     }
 
@@ -158,6 +166,7 @@ public class UtilisateurController {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<String> handleIllegalState(IllegalStateException ex) {
+        log.error("Erreur inattendue dans UtilisateurController : {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 

--- a/src/main/java/com/PapoteCar/PapoteCar/controller/VoitureController.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/controller/VoitureController.java
@@ -10,6 +10,7 @@ import com.PapoteCar.PapoteCar.repository.TrajetRepository;
 import com.PapoteCar.PapoteCar.repository.UtilisateurRepository;
 import com.PapoteCar.PapoteCar.repository.VoitureRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class VoitureController {
@@ -50,6 +52,7 @@ public class VoitureController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!voitureRepository.existsByIdAndUtilisateurId(id, connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} tente d'accéder à la voiture id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -76,6 +79,7 @@ public class VoitureController {
         voiture.setTailleCoffre(request.getTailleCoffre());
 
         Voiture sauvegardee = voitureRepository.save(voiture);
+        log.info("Voiture créée id={} pour utilisateur id={}", sauvegardee.getId(), connecte.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new VoitureResponse(sauvegardee.getId(), sauvegardee.getModele(), sauvegardee.getNbPassagers(), sauvegardee.getCouleur(), sauvegardee.getTailleCoffre()));
@@ -92,11 +96,13 @@ public class VoitureController {
 
         Utilisateur connecte = utilisateurConnecte();
         if (!voitureRepository.existsByIdAndUtilisateurId(id, connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} ne possède pas la voiture id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajetRepository.existsByVoitureIdAndStatut(id, Trajet.Statut.actif)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit modification voiture id={} : trajet actif en cours", id);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de modifier cette voiture : un trajet actif l'utilise actuellement");
         }
 
         if (request.getModele() != null && request.getModele().isBlank()) {
@@ -112,26 +118,30 @@ public class VoitureController {
         if (request.getTailleCoffre() != null) voiture.setTailleCoffre(request.getTailleCoffre());
 
         voitureRepository.save(voiture);
+        log.info("Voiture mise à jour id={} par utilisateur id={}", id, connecte.getId());
 
         return ResponseEntity.ok(new VoitureResponse(voiture.getId(), voiture.getModele(), voiture.getNbPassagers(), voiture.getCouleur(), voiture.getTailleCoffre()));
     }
 
     // DELETE /voiture/{id} — supprimer une voiture (ownership + guard trajet actif)
     @DeleteMapping("/voiture/{id}")
-    public ResponseEntity<Void> deleteVoiture(@PathVariable Integer id) {
+    public ResponseEntity<?> deleteVoiture(@PathVariable Integer id) {
         voitureRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Voiture introuvable"));
 
         Utilisateur connecte = utilisateurConnecte();
         if (!voitureRepository.existsByIdAndUtilisateurId(id, connecte.getId())) {
+            log.warn("Accès interdit : utilisateur id={} ne possède pas la voiture id={}", connecte.getId(), id);
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         if (trajetRepository.existsByVoitureIdAndStatut(id, Trajet.Statut.actif)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+            log.warn("Conflit suppression voiture id={} : trajet actif en cours", id);
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("Impossible de supprimer cette voiture : un trajet actif l'utilise actuellement");
         }
 
         voitureRepository.deleteById(id);
+        log.info("Voiture supprimée id={} par utilisateur id={}", id, connecte.getId());
         return ResponseEntity.noContent().build();
     }
 
@@ -142,6 +152,7 @@ public class VoitureController {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<String> handleIllegalState(IllegalStateException ex) {
+        log.error("Erreur inattendue dans VoitureController : {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/PapoteCar/PapoteCar/service/AuthService.java
+++ b/src/main/java/com/PapoteCar/PapoteCar/service/AuthService.java
@@ -7,6 +7,7 @@ import com.PapoteCar.PapoteCar.model.Utilisateur;
 import com.PapoteCar.PapoteCar.repository.UtilisateurRepository;
 import com.PapoteCar.PapoteCar.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -24,9 +26,11 @@ public class AuthService {
 
     public AuthResponse register(RegisterRequest request) {
         if (utilisateurRepository.existsByEmail(request.getEmail())) {
+            log.warn("Tentative d'inscription avec un email déjà utilisé : {}", request.getEmail());
             throw new IllegalArgumentException("Email déjà utilisé");
         }
         if (utilisateurRepository.existsByUsername(request.getUsername())) {
+            log.warn("Tentative d'inscription avec un username déjà utilisé : {}", request.getUsername());
             throw new IllegalArgumentException("Username déjà utilisé");
         }
 
@@ -38,6 +42,7 @@ public class AuthService {
         utilisateur.setMotDePasse(passwordEncoder.encode(request.getMotDePasse()));
         utilisateur.setTel(request.getTel());
         utilisateurRepository.save(utilisateur);
+        log.info("Nouvel utilisateur enregistré : email={}, username={}", utilisateur.getEmail(), utilisateur.getUsername());
 
         String token = jwtUtil.generateToken(utilisateur.getEmail());
         return new AuthResponse(token, expireLabel());
@@ -53,13 +58,18 @@ public class AuthService {
         Utilisateur utilisateur = (login.contains("@")
                 ? utilisateurRepository.findByEmail(login)
                 : utilisateurRepository.findByUsername(login))
-                .orElseThrow(() -> new IllegalArgumentException("Utilisateur introuvable : " + login));
+                .orElseThrow(() -> {
+                    log.warn("Tentative de connexion avec un identifiant inconnu : {}", login);
+                    return new IllegalArgumentException("Utilisateur introuvable : " + login);
+                });
 
         if (!passwordEncoder.matches(request.getMotDePasse(), utilisateur.getMotDePasse())) {
+            log.warn("Mot de passe incorrect pour l'identifiant : {}", login);
             throw new IllegalArgumentException("Mot de passe incorrect pour : " + login);
         }
 
         String token = jwtUtil.generateToken(utilisateur.getEmail());
+        log.info("Connexion réussie pour : {}", login);
         return new AuthResponse(token, expireLabel());
     }
 


### PR DESCRIPTION
   - Ajout @Slf4j sur ReservationController, TrajetController (et autres) avec logs warn/info sur les accès interdits, conflits et créations
   - Les réponses 409/400/403 renvoient désormais un body texte explicatif au lieu d'un corps vide
   - GET /trajets et GET /trajets/{id} rendus publics (sans token) dans SecurityConfig
   - Jeu de données 02_data.sql enrichi avec scénarios variés (soldes différents, permis, trajets, réservations)